### PR TITLE
catch all 400 http errors identically

### DIFF
--- a/repo
+++ b/repo
@@ -463,7 +463,8 @@ def _DownloadBundle(url, local, quiet):
     try:
       r = urllib.request.urlopen(url)
     except urllib.error.HTTPError as e:
-      if e.code in [401, 403, 404]:
+      # 4** error
+      if 400 <= e.code < 500:
         return False
       _print('fatal: Cannot get %s' % url, file=sys.stderr)
       _print('fatal: HTTP error %s' % e.code, file=sys.stderr)


### PR DESCRIPTION
example of why this is needed: https://archive.mozilla.org/pub/firefox/tinderbox-builds/mozilla-release-macosx64/release-mozilla-release-firefox-linux64_partner_repacks-bm84-build1-build23.txt.gz

verified this patch fixes things locally.

thanks to @rail for discovering and investigating.