### PR TITLE
Bug 1653169 - Use py2 for this old copy of repo

### DIFF
--- a/repo
+++ b/repo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 ## repo default configuration
 ##


### PR DESCRIPTION
This is a stop-gap for [bug 1653169](https://bugzilla.mozilla.org/show_bug.cgi?id=1653169), working around the bustage of this old copy of the repo tool with python3. The followup will be to merge from upstream.